### PR TITLE
Add types to enable option-aware mixins.

### DIFF
--- a/src/types/__tests__/bar.ts
+++ b/src/types/__tests__/bar.ts
@@ -1,0 +1,16 @@
+import { Constructor } from '../types.constructor';
+import { HasOptions } from '../types.options';
+
+export interface BarOptions {
+    bar?: number;
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function Bar<B extends Constructor<HasOptions<BarOptions>>>(Base: B) {
+    return class BarMixin extends Base {
+
+        public bar(): number | undefined {
+            return this.options.bar;
+        }
+    };
+}

--- a/src/types/__tests__/foo.ts
+++ b/src/types/__tests__/foo.ts
@@ -1,0 +1,16 @@
+import { Constructor } from '../types.constructor';
+import { HasOptions } from '../types.options';
+
+export interface FooOptions {
+    foo: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function Foo<B extends Constructor<HasOptions<FooOptions>>>(Base: B) {
+    return class FooMixin extends Base {
+
+        public foo(): string {
+            return this.options.foo;
+        }
+    };
+}

--- a/src/types/__tests__/mixin.test.ts
+++ b/src/types/__tests__/mixin.test.ts
@@ -1,0 +1,17 @@
+import { WithOptions } from '../types.options';
+import { BarOptions, Bar } from './bar';
+import { FooOptions, Foo } from './foo';
+
+type FooAndBarOptions = FooOptions & BarOptions;
+const FooAndBar = Bar(Foo(WithOptions<FooAndBarOptions>()));
+
+describe('mixins', () => {
+    it('have access to typed options ', () => {
+        const mixin = new FooAndBar({
+            foo: 'foo',
+        });
+        expect(mixin).toBeDefined();
+        expect(mixin.foo()).toEqual('foo');
+        expect(mixin.bar()).toBeUndefined();
+    });
+});

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './types.options';

--- a/src/types/types.constructor.ts
+++ b/src/types/types.constructor.ts
@@ -1,0 +1,10 @@
+/* The recommended TypeScript mixin pattern depends on having a Constructor type.
+ *
+ * See: https://www.typescriptlang.org/docs/handbook/mixins.html
+ */
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export interface Constructor<T = {}> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    new (...args: any[]): T;
+}

--- a/src/types/types.options.ts
+++ b/src/types/types.options.ts
@@ -1,0 +1,25 @@
+/* Decorator mixins need access to type-specific options.
+ *
+ * To make this work, we need both a way for each mixin to express the options
+ * it needs and a way to ensure that options are accessible in a base class.
+ */
+import { Constructor } from './types.constructor';
+
+/* An interface that expresses that a type has a particular kind of options.
+ */
+export interface HasOptions<Options> {
+    options: Options;
+}
+
+/* A mixin factory that adds support for options building.
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function WithOptions<Options>(Base: Constructor = Object) {
+    return class WithOptionsMixin extends Base implements HasOptions<Options> {
+        constructor(
+            public readonly options: Options,
+        ) {
+            super();
+        }
+    };
+}


### PR DESCRIPTION
We want our DTO decorator mixin types to support type-specific options.
Before writing those types, add some boilerplate for writing such mixins.