### PR TITLE
Add swagger mixin and rename other mixins

### DIFF
--- a/src/mixins/__tests__/transformer.mixin.test.ts
+++ b/src/mixins/__tests__/transformer.mixin.test.ts
@@ -1,12 +1,12 @@
 import { plainToClass } from 'class-transformer';
 
 import { createBuilder } from '../../builders';
-import { ClassTransformerOptions, withClassTransformer } from '../class-transformer.mixin';
+import { TransformerOptions, withTransformer } from '../transformer.mixin';
 
-const Builder = withClassTransformer(createBuilder<ClassTransformerOptions>());
+const Builder = withTransformer(createBuilder<TransformerOptions>());
 
 describe('mixins', () => {
-    describe('ClassTransformerMixin', () => {
+    describe('TransformerMixin', () => {
         const options = {
             excludeExtraneousValues: true,
         };

--- a/src/mixins/__tests__/validator.mixin.test.ts
+++ b/src/mixins/__tests__/validator.mixin.test.ts
@@ -1,12 +1,12 @@
 import { getMetadataStorage } from 'class-validator';
 
 import { createBuilder } from '../../builders';
-import { ClassValidatorOptions, withClassValidator } from '../class-validator.mixin';
+import { ValidatorOptions, withValidator } from '../validator.mixin';
 
-const Builder = withClassValidator(createBuilder<ClassValidatorOptions>());
+const Builder = withValidator(createBuilder<ValidatorOptions>());
 
 describe('mixins', () => {
-    describe('ClassValidatorMixin', () => {
+    describe('ValidatorMixin', () => {
         const metadataStorage = getMetadataStorage();
 
         it('defaults to required', () => {

--- a/src/mixins/index.ts
+++ b/src/mixins/index.ts
@@ -1,0 +1,3 @@
+export * from './swagger.mixin';
+export * from './transformer.mixin';
+export * from './validator.mixin';

--- a/src/mixins/swagger.mixin.ts
+++ b/src/mixins/swagger.mixin.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Constructor, HasInputDecorators, HasOptions } from '../interfaces';
+
+export interface SwaggerOptions {
+    description?: string;
+    format?: string;
+    nullable?: boolean;
+    type?: string,
+}
+
+type BaseBuilder = HasInputDecorators & HasOptions<SwaggerOptions>;
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function withSwagger<B extends Constructor<BaseBuilder>>(Base: B) {
+    return class ClassValidatorMixin extends Base {
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        constructor(...args: any[]) {
+            super(...args);
+
+            this.api();
+        }
+
+        public api(): this {
+            this.add(
+                ApiProperty({
+                    description: this.options.description,
+                    format: this.options.format,
+                    nullable: this.options.nullable,
+                    type: this.options.type,
+                }),
+            );
+            return this;
+        }
+    };
+}

--- a/src/mixins/transformer.mixin.ts
+++ b/src/mixins/transformer.mixin.ts
@@ -2,14 +2,14 @@ import { Expose } from 'class-transformer';
 
 import { Constructor, HasInputDecorators, HasOptions } from '../interfaces';
 
-export interface ClassTransformerOptions {
+export interface TransformerOptions {
     expose?: boolean;
 }
 
-type BaseBuilder = HasInputDecorators & HasOptions<ClassTransformerOptions>;
+type BaseBuilder = HasInputDecorators & HasOptions<TransformerOptions>;
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function withClassTransformer<B extends Constructor<BaseBuilder>>(Base: B) {
+export function withTransformer<B extends Constructor<BaseBuilder>>(Base: B) {
     return class ClassTransformerMixin extends Base {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/mixins/validator.mixin.ts
+++ b/src/mixins/validator.mixin.ts
@@ -2,15 +2,15 @@ import { IsDefined, IsOptional } from 'class-validator';
 
 import { Constructor, HasInputDecorators, HasOptions } from '../interfaces';
 
-export interface ClassValidatorOptions {
+export interface ValidatorOptions {
     optional?: boolean;
 }
 
-type BaseBuilder = HasInputDecorators & HasOptions<ClassValidatorOptions>;
+type BaseBuilder = HasInputDecorators & HasOptions<ValidatorOptions>;
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function withClassValidator<B extends Constructor<BaseBuilder>>(Base: B) {
-    return class ClassValidatorMixin extends Base {
+export function withValidator<B extends Constructor<BaseBuilder>>(Base: B) {
+    return class ValidatorMixin extends Base {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         constructor(...args: any[]) {


### PR DESCRIPTION
 - Adds swagger mixin
 - Omits swagger mixin tests due to complexity of accessing the resulting metadata
   and of invoking swagger generation in isolation.
 - Renamed all mixins using shorter forms; we can assume class-* and @nestjs