### PR TITLE
Rename Swagger flavor to OpenAPI

### DIFF
--- a/openapi.ts
+++ b/openapi.ts
@@ -1,0 +1,1 @@
+export * from './src/flavors/openapi';

--- a/src/flavors/__tests__/__snapshots__/openapi.test.ts.snap
+++ b/src/flavors/__tests__/__snapshots__/openapi.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`flavors.swagger does not transform input data if extraneous values are excluded 1`] = `
+exports[`flavors.openapi does not transform input data if extraneous values are excluded 1`] = `
 Array [
   ValidationError {
     "children": Array [],
@@ -84,7 +84,7 @@ Array [
 ]
 `;
 
-exports[`flavors.swagger generates swagger 1`] = `
+exports[`flavors.openapi generates OpenAPI spec 1`] = `
 Object {
   "components": Object {
     "schemas": Object {
@@ -225,11 +225,11 @@ Object {
 }
 `;
 
-exports[`flavors.swagger transforms input data 1`] = `Array []`;
+exports[`flavors.openapi transforms input data 1`] = `Array []`;
 
-exports[`flavors.swagger validates required fields 1`] = `Example {}`;
+exports[`flavors.openapi validates required fields 1`] = `Example {}`;
 
-exports[`flavors.swagger validates required fields 2`] = `
+exports[`flavors.openapi validates required fields 2`] = `
 Array [
   ValidationError {
     "children": Array [],

--- a/src/flavors/__tests__/fixtures.ts
+++ b/src/flavors/__tests__/fixtures.ts
@@ -1,6 +1,6 @@
 import { Constructor } from '../../interfaces';
 
-import { BasicFlavor, SwaggerFlavor } from '..';
+import { BasicFlavor, OpenAPIFlavor } from '..';
 
 export function createFixtures(
     /* It is rather difficult to write `createFixtures()` as a generic function
@@ -15,7 +15,7 @@ export function createFixtures(
      *
      * It is, however, easy to allow a union of the flavors we wish to support.
      */
-    flavor: BasicFlavor | SwaggerFlavor,
+    flavor: BasicFlavor | OpenAPIFlavor,
 ): Constructor {
     const {
         IsBoolean,

--- a/src/flavors/__tests__/openapi.test.ts
+++ b/src/flavors/__tests__/openapi.test.ts
@@ -4,10 +4,10 @@ import { Test } from '@nestjs/testing';
 import { plainToClass } from 'class-transformer';
 import { validate } from 'class-validator';
 
-import { flavor } from '../swagger';
+import { flavor } from '../openapi';
 import { INPUT, createFixtures } from './fixtures';
 
-describe('flavors.swagger', () => {
+describe('flavors.openapi', () => {
     const Example = createFixtures(flavor);
 
     /* NB: it's tricky to correctly define the return type of `createFixtures` and
@@ -76,7 +76,7 @@ describe('flavors.swagger', () => {
         expect(errors).toHaveLength(8);
         expect(errors).toMatchSnapshot();
     });
-    it('generates swagger', async () => {
+    it('generates OpenAPI spec', async () => {
         const moduleRef = await Test.createTestingModule({
             controllers: [
                 ExampleController,

--- a/src/flavors/index.ts
+++ b/src/flavors/index.ts
@@ -1,2 +1,2 @@
 export { flavor as basic, BasicFlavor } from './basic';
-export { flavor as swagger, SwaggerFlavor } from './swagger';
+export { flavor as openapi, OpenAPIFlavor } from './openapi';

--- a/src/flavors/openapi.ts
+++ b/src/flavors/openapi.ts
@@ -55,4 +55,4 @@ export const flavor: Flavor<FlavorOptions> = {
     IsUUID: IsUUIDFactory(createBuilderWithMixins<FlavorOptions & UUIDOptions>()),
 };
 
-export type SwaggerFlavor = typeof flavor;
+export type OpenAPIFlavor = typeof flavor;

--- a/swagger.ts
+++ b/swagger.ts
@@ -1,1 +1,0 @@
-export * from './src/flavors/swagger';


### PR DESCRIPTION
 - Use the preferred community naming.
 - Preserve the use of "swagger" where referring to `@nestjs/swagger` (mixin)