### PR TITLE
Enable nullable decorator properties.

### DIFF
--- a/src/flavors/__tests__/__snapshots__/openapi.test.ts.snap
+++ b/src/flavors/__tests__/__snapshots__/openapi.test.ts.snap
@@ -100,6 +100,49 @@ Object {
     "schemas": Object {
       "ExampleDTO": Object {
         "properties": Object {
+          "nullableBooleanValue": Object {
+            "nullable": true,
+            "type": "boolean",
+          },
+          "nullableDateStringValue": Object {
+            "format": "date",
+            "nullable": true,
+            "type": "string",
+          },
+          "nullableDateValue": Object {
+            "format": "date-time",
+            "nullable": true,
+            "type": "string",
+          },
+          "nullableEnumValue": Object {
+            "$ref": "#/components/schemas/Object",
+            "nullable": true,
+          },
+          "nullableIntegerValue": Object {
+            "nullable": true,
+            "type": "integer",
+          },
+          "nullableNestedValue": Object {
+            "allOf": Array [
+              Object {
+                "$ref": "#/components/schemas/NestedNullableExample",
+              },
+            ],
+            "nullable": true,
+          },
+          "nullableNumberValue": Object {
+            "nullable": true,
+            "type": "number",
+          },
+          "nullableStringValue": Object {
+            "nullable": true,
+            "type": "string",
+          },
+          "nullableUUIDValue": Object {
+            "format": "uuid",
+            "nullable": true,
+            "type": "string",
+          },
           "optionalBooleanValue": Object {
             "type": "boolean",
           },
@@ -171,6 +214,26 @@ Object {
           "requiredNumberValue",
           "requiredStringValue",
           "requiredUUIDValue",
+          "nullableBooleanValue",
+          "nullableDateStringValue",
+          "nullableDateValue",
+          "nullableEnumValue",
+          "nullableIntegerValue",
+          "nullableNestedValue",
+          "nullableNumberValue",
+          "nullableStringValue",
+          "nullableUUIDValue",
+        ],
+        "type": "object",
+      },
+      "NestedNullableExample": Object {
+        "properties": Object {
+          "nullableStringValue": Object {
+            "type": "string",
+          },
+        },
+        "required": Array [
+          "nullableStringValue",
         ],
         "type": "object",
       },

--- a/src/flavors/__tests__/basic.test.ts
+++ b/src/flavors/__tests__/basic.test.ts
@@ -23,13 +23,16 @@ describe('flavors.basic', () => {
         const obj = plainToClass(Example, INPUT);
 
         // expect all data to be transformed
-        expect(Object.keys(obj)).toHaveLength(18);
+        expect(Object.keys(obj)).toHaveLength(27);
         expect(obj).toMatchObject({
             requiredNestedValue: {
                 requiredStringValue: 'nested',
             },
             optionalNestedValue: {
                 optionalStringValue: 'nested',
+            },
+            nullableNestedValue: {
+                nullableStringValue: 'nested',
             },
         });
 

--- a/src/flavors/__tests__/fixtures.ts
+++ b/src/flavors/__tests__/fixtures.ts
@@ -43,7 +43,14 @@ export function createFixtures(
         optionalStringValue?: string;
     }
 
+    class NestedNullableExample {
+        @IsString()
+        nullableStringValue!: string | null;
+    }
+
     class Example {
+        /* Create one property of each type that is required. */
+
         @IsBoolean()
         requiredBooleanValue!: boolean;
 
@@ -74,6 +81,8 @@ export function createFixtures(
 
         @IsUUID()
         requiredUUIDValue!: string;
+
+        /* Create one property of each type that is optional. */
 
         @IsBoolean({
             optional: true,
@@ -121,6 +130,55 @@ export function createFixtures(
             optional: true,
         })
         optionalUUIDValue?: string;
+
+        /* Create one property of each type that is nullable. */
+
+        @IsBoolean({
+            nullable: true,
+        })
+        nullableBooleanValue!: boolean | null;
+
+        @IsDateString({
+            nullable: true,
+        })
+        nullableDateStringValue!: string | null;
+
+        @IsDate({
+            nullable: true,
+        })
+        nullableDateValue!: Date | null;
+
+        @IsEnum({
+            enum: ExampleEnum,
+            nullable: true,
+        })
+        nullableEnumValue!: ExampleEnum | null;
+
+        @IsInteger({
+            nullable: true,
+        })
+        nullableIntegerValue!: number | null;
+
+        @IsNested({
+            nested: NestedNullableExample,
+            nullable: true,
+        })
+        nullableNestedValue!: NestedNullableExample | null;
+
+        @IsNumber({
+            nullable: true,
+        })
+        nullableNumberValue!: number | null;
+
+        @IsString({
+            nullable: true,
+        })
+        nullableStringValue!: string | null;
+
+        @IsUUID({
+            nullable: true,
+        })
+        nullableUUIDValue!: string | null;
     }
 
     return Example;
@@ -150,4 +208,16 @@ export const INPUT = {
     optionalNumberValue: '42.0',
     optionalStringValue: 'value',
     optionalUUIDValue: '3430cef4-6e7a-43da-a5a7-ae4c6a18be47',
+
+    nullableBooleanValue: 'true',
+    nullableDateStringValue: '2021-01-12',
+    nullableDateValue: '2021-01-12T01:12:38.956Z',
+    nullableEnumValue: 'Value',
+    nullableIntegerValue: '42',
+    nullableNestedValue: {
+        nullableStringValue: 'nested',
+    },
+    nullableNumberValue: '42.0',
+    nullableStringValue: 'value',
+    nullableUUIDValue: '3430cef4-6e7a-43da-a5a7-ae4c6a18be47',
 };

--- a/src/flavors/__tests__/openapi.test.ts
+++ b/src/flavors/__tests__/openapi.test.ts
@@ -48,13 +48,16 @@ describe('flavors.openapi', () => {
         const obj = plainToClass(Example, INPUT);
 
         // expect all data to be transformed
-        expect(Object.keys(obj)).toHaveLength(18);
+        expect(Object.keys(obj)).toHaveLength(27);
         expect(obj).toMatchObject({
             requiredNestedValue: {
                 requiredStringValue: 'nested',
             },
             optionalNestedValue: {
                 optionalStringValue: 'nested',
+            },
+            nullableNestedValue: {
+                nullableStringValue: 'nested',
             },
         });
 

--- a/src/mixins/validator.mixin.ts
+++ b/src/mixins/validator.mixin.ts
@@ -3,6 +3,9 @@ import { IsDefined, IsOptional } from 'class-validator';
 import { BuilderClass, Constructor } from '../interfaces';
 
 export interface ValidatorOptions {
+    // nullable means that the value type should be "T | null"
+    nullable?: boolean;
+    // optional means that the value type should be "T | undefined"
     optional?: boolean;
 }
 
@@ -18,7 +21,7 @@ export function withValidator<B extends BuilderClass<ValidatorOptions>>(Base: B)
         constructor(...args: any[]) {
             super(...args);
 
-            if (this.options.optional) {
+            if (this.options.optional || this.options.nullable) {
                 this.optional();
             } else {
                 this.required();


### PR DESCRIPTION
We differentiate `optional` and `nullable` properties where the former
means `T | undefined` and the latter means `T | null`.

 -  Add `nullable` to the `class-validator` mixin's support options.
 -  Add test cases for nullable properties of each type.