### PR TITLE
Decouple per-receipt options from mixin options.

### DIFF
--- a/src/flavors/__tests__/fixtures.ts
+++ b/src/flavors/__tests__/fixtures.ts
@@ -1,22 +1,6 @@
-import { Constructor } from '../../interfaces';
+import { Constructor, Flavor } from '../../interfaces';
 
-import { BasicFlavor, OpenAPIFlavor } from '..';
-
-export function createFixtures(
-    /* It is rather difficult to write `createFixtures()` as a generic function
-     * that accepts any flavor of decorators.
-     *
-     * For example, attempts to add a generic Options options parameter, even one constrained
-     * to available mixin options, lead to compiler errors of the form:
-     *
-     *  "could be instantiated with a different subtype of constraint"
-     *
-     * because the compiler isn't powerful enough to perform "higher-order" type reasoning.
-     *
-     * It is, however, easy to allow a union of the flavors we wish to support.
-     */
-    flavor: BasicFlavor | OpenAPIFlavor,
-): Constructor {
+export function createFixtures(flavor: Flavor): Constructor {
     const {
         IsArray,
         IsBoolean,

--- a/src/flavors/basic.ts
+++ b/src/flavors/basic.ts
@@ -15,8 +15,6 @@ import {
     UUIDOptions,
 } from '../interfaces';
 import {
-    TransformerOptions,
-    ValidatorOptions,
     withTransformer,
     withValidator,
 } from '../mixins';
@@ -33,8 +31,6 @@ import {
     IsUUIDRecipe,
 } from '../recipes';
 
-export interface FlavorOptions extends TransformerOptions, ValidatorOptions {}
-
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 function createBuilderWithMixins<Options>() {
     return withTransformer(
@@ -44,17 +40,15 @@ function createBuilderWithMixins<Options>() {
     );
 }
 
-export const flavor: Flavor<FlavorOptions> = {
-    IsArray: IsArrayRecipe(createBuilderWithMixins<FlavorOptions & ArrayOptions>()),
-    IsBoolean: IsBooleanRecipe(createBuilderWithMixins<FlavorOptions & BooleanOptions>()),
-    IsDate: IsDateRecipe(createBuilderWithMixins<FlavorOptions & DateOptions>()),
-    IsDateString: IsDateStringRecipe(createBuilderWithMixins<FlavorOptions & DateStringOptions>()),
-    IsEnum: IsEnumRecipe(createBuilderWithMixins<FlavorOptions & EnumOptions>()),
-    IsInteger: IsIntegerRecipe(createBuilderWithMixins<FlavorOptions & IntegerOptions>()),
-    IsNested: IsNestedRecipe(createBuilderWithMixins<FlavorOptions & NestedOptions>()),
-    IsNumber: IsNumberRecipe(createBuilderWithMixins<FlavorOptions & NumberOptions>()),
-    IsString: IsStringRecipe(createBuilderWithMixins<FlavorOptions & StringOptions>()),
-    IsUUID: IsUUIDRecipe(createBuilderWithMixins<FlavorOptions & UUIDOptions>()),
+export const flavor: Flavor = {
+    IsArray: IsArrayRecipe(createBuilderWithMixins<ArrayOptions>()),
+    IsBoolean: IsBooleanRecipe(createBuilderWithMixins<BooleanOptions>()),
+    IsDate: IsDateRecipe(createBuilderWithMixins<DateOptions>()),
+    IsDateString: IsDateStringRecipe(createBuilderWithMixins<DateStringOptions>()),
+    IsEnum: IsEnumRecipe(createBuilderWithMixins<EnumOptions>()),
+    IsInteger: IsIntegerRecipe(createBuilderWithMixins<IntegerOptions>()),
+    IsNested: IsNestedRecipe(createBuilderWithMixins<NestedOptions>()),
+    IsNumber: IsNumberRecipe(createBuilderWithMixins<NumberOptions>()),
+    IsString: IsStringRecipe(createBuilderWithMixins<StringOptions>()),
+    IsUUID: IsUUIDRecipe(createBuilderWithMixins<UUIDOptions>()),
 };
-
-export type BasicFlavor = typeof flavor;

--- a/src/flavors/index.ts
+++ b/src/flavors/index.ts
@@ -1,2 +1,2 @@
-export { flavor as basic, BasicFlavor } from './basic';
-export { flavor as openapi, OpenAPIFlavor } from './openapi';
+export { flavor as basic } from './basic';
+export { flavor as openapi } from './openapi';

--- a/src/flavors/openapi.ts
+++ b/src/flavors/openapi.ts
@@ -15,9 +15,6 @@ import {
     UUIDOptions,
 } from '../interfaces';
 import {
-    SwaggerOptions,
-    TransformerOptions,
-    ValidatorOptions,
     withSwagger,
     withTransformer,
     withValidator,
@@ -35,8 +32,6 @@ import {
     IsUUIDRecipe,
 } from '../recipes';
 
-export interface FlavorOptions extends SwaggerOptions, TransformerOptions, ValidatorOptions {}
-
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 function createBuilderWithMixins<Options>() {
     return withSwagger(
@@ -48,17 +43,15 @@ function createBuilderWithMixins<Options>() {
     );
 }
 
-export const flavor: Flavor<FlavorOptions> = {
-    IsArray: IsArrayRecipe(createBuilderWithMixins<FlavorOptions & ArrayOptions>()),
-    IsBoolean: IsBooleanRecipe(createBuilderWithMixins<FlavorOptions & BooleanOptions>()),
-    IsDate: IsDateRecipe(createBuilderWithMixins<FlavorOptions & DateOptions>()),
-    IsDateString: IsDateStringRecipe(createBuilderWithMixins<FlavorOptions & DateStringOptions>()),
-    IsEnum: IsEnumRecipe(createBuilderWithMixins<FlavorOptions & EnumOptions>()),
-    IsInteger: IsIntegerRecipe(createBuilderWithMixins<FlavorOptions & IntegerOptions>()),
-    IsNested: IsNestedRecipe(createBuilderWithMixins<FlavorOptions & NestedOptions>()),
-    IsNumber: IsNumberRecipe(createBuilderWithMixins<FlavorOptions & NumberOptions>()),
-    IsString: IsStringRecipe(createBuilderWithMixins<FlavorOptions & StringOptions>()),
-    IsUUID: IsUUIDRecipe(createBuilderWithMixins<FlavorOptions & UUIDOptions>()),
+export const flavor: Flavor = {
+    IsArray: IsArrayRecipe(createBuilderWithMixins<ArrayOptions>()),
+    IsBoolean: IsBooleanRecipe(createBuilderWithMixins<BooleanOptions>()),
+    IsDate: IsDateRecipe(createBuilderWithMixins<DateOptions>()),
+    IsDateString: IsDateStringRecipe(createBuilderWithMixins<DateStringOptions>()),
+    IsEnum: IsEnumRecipe(createBuilderWithMixins<EnumOptions>()),
+    IsInteger: IsIntegerRecipe(createBuilderWithMixins<IntegerOptions>()),
+    IsNested: IsNestedRecipe(createBuilderWithMixins<NestedOptions>()),
+    IsNumber: IsNumberRecipe(createBuilderWithMixins<NumberOptions>()),
+    IsString: IsStringRecipe(createBuilderWithMixins<StringOptions>()),
+    IsUUID: IsUUIDRecipe(createBuilderWithMixins<UUIDOptions>()),
 };
-
-export type OpenAPIFlavor = typeof flavor;

--- a/src/interfaces/flavor.ts
+++ b/src/interfaces/flavor.ts
@@ -13,18 +13,15 @@ import {
 
 /* A collection of decorator recipes using a specific options type.
  */
-export interface Flavor<Options> {
-    // NB: IsArray has mandatory options
-    IsArray: (options: Options & ArrayOptions) => PropertyDecorator,
-    IsBoolean: (options?: Options & BooleanOptions) => PropertyDecorator,
-    IsDate: (options?: Options & DateOptions) => PropertyDecorator,
-    IsDateString: (options?: Options & DateStringOptions) => PropertyDecorator,
-    // NB: IsEnum has mandatory options
-    IsEnum: (options: Options & EnumOptions) => PropertyDecorator,
-    IsInteger: (options?: Options & IntegerOptions) => PropertyDecorator,
-    // NB: IsNested has mandatory options
-    IsNested: (options: Options & NestedOptions) => PropertyDecorator;
-    IsNumber: (options?: Options & NumberOptions) => PropertyDecorator,
-    IsString: (options?: Options & StringOptions) => PropertyDecorator,
-    IsUUID: (options?: Options & UUIDOptions) => PropertyDecorator,
+export interface Flavor {
+    IsArray: (options: ArrayOptions) => PropertyDecorator,
+    IsBoolean: (options?: BooleanOptions) => PropertyDecorator,
+    IsDate: (options?: DateOptions) => PropertyDecorator,
+    IsDateString: (options?: DateStringOptions) => PropertyDecorator,
+    IsEnum: (options: EnumOptions) => PropertyDecorator,
+    IsInteger: (options?: IntegerOptions) => PropertyDecorator,
+    IsNested: (options: NestedOptions) => PropertyDecorator;
+    IsNumber: (options?: NumberOptions) => PropertyDecorator,
+    IsString: (options?: StringOptions) => PropertyDecorator,
+    IsUUID: (options?: UUIDOptions) => PropertyDecorator,
 }

--- a/src/interfaces/options/array.options.ts
+++ b/src/interfaces/options/array.options.ts
@@ -4,4 +4,6 @@ export interface ArrayOptions {
     type: Constructor,
     maxItems?: number,
     minItems?: number,
+    nullable?: boolean,
+    optional?: boolean,
 }

--- a/src/interfaces/options/boolean.options.ts
+++ b/src/interfaces/options/boolean.options.ts
@@ -1,2 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface BooleanOptions {}
+export interface BooleanOptions {
+    nullable?: boolean,
+    optional?: boolean,
+}

--- a/src/interfaces/options/date-string.options.ts
+++ b/src/interfaces/options/date-string.options.ts
@@ -1,3 +1,4 @@
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface DateStringOptions {
+    nullable?: boolean,
+    optional?: boolean,
 }

--- a/src/interfaces/options/date.options.ts
+++ b/src/interfaces/options/date.options.ts
@@ -1,3 +1,5 @@
 export interface DateOptions {
     format?: string,
+    nullable?: boolean,
+    optional?: boolean,
 }

--- a/src/interfaces/options/enum.options.ts
+++ b/src/interfaces/options/enum.options.ts
@@ -1,4 +1,6 @@
 export interface EnumOptions {
     enum: Record<string, unknown>,
     enumName?: string;
+    nullable?: boolean,
+    optional?: boolean,
 }

--- a/src/interfaces/options/integer.options.ts
+++ b/src/interfaces/options/integer.options.ts
@@ -1,4 +1,6 @@
 export interface IntegerOptions {
     maxValue?: number,
     minValue?: number,
+    nullable?: boolean,
+    optional?: boolean,
 }

--- a/src/interfaces/options/nested.options.ts
+++ b/src/interfaces/options/nested.options.ts
@@ -1,5 +1,7 @@
 import { Constructor } from '../constructor';
 
 export interface NestedOptions {
+    nullable?: boolean,
+    optional?: boolean,
     type: Constructor,
 }

--- a/src/interfaces/options/number.options.ts
+++ b/src/interfaces/options/number.options.ts
@@ -1,4 +1,6 @@
 export interface NumberOptions {
     maxValue?: number,
     minValue?: number,
+    nullable?: boolean,
+    optional?: boolean,
 }

--- a/src/interfaces/options/string.options.ts
+++ b/src/interfaces/options/string.options.ts
@@ -1,5 +1,7 @@
 export interface StringOptions {
-    pattern?: RegExp;
     maxLength?: number,
     minLength?: number,
+    nullable?: boolean,
+    optional?: boolean,
+    pattern?: RegExp;
 }

--- a/src/interfaces/options/uuid.options.ts
+++ b/src/interfaces/options/uuid.options.ts
@@ -1,3 +1,5 @@
 export interface UUIDOptions {
+    nullable?: boolean,
+    optional?: boolean,
     version?: '3'|'4'|'5'|'all',
 }


### PR DESCRIPTION
My original intention was to expose the mixin features directly, but as the
implementation has progressed, it's become clearer that we mostly want to
have a small set of type-specific options for each decorator/recipe.

This means I can hide/decouple the mixin options from the decorators, which
has a number of benfits:

 - Decorator usage is more type safe. For example, we can't pass `minLength`
   to `IsArray`, even though the openapi mixin supports it.

 - The `Flavor` type is no longer a generic, which greatly simplifies type
   signatures of any function accepting a flavor.

 - The choice to use mixins is now separable and can be revisited without
   impacting the flavor API. This is a big win since mixins are complicated
   and might be worth removing now that the approach to composition is clearer.