### PR TITLE
Do not use constructor for default enum name

### DIFF
--- a/src/flavors/__tests__/__snapshots__/openapi.test.ts.snap
+++ b/src/flavors/__tests__/__snapshots__/openapi.test.ts.snap
@@ -118,6 +118,12 @@ exports[`flavors.openapi generates OpenAPI spec 1`] = `
 Object {
   "components": Object {
     "schemas": Object {
+      "Example": Object {
+        "enum": Array [
+          "Value",
+        ],
+        "type": "string",
+      },
       "ExampleDTO": Object {
         "properties": Object {
           "nullableBooleanValue": Object {
@@ -135,7 +141,7 @@ Object {
             "type": "string",
           },
           "nullableEnumValue": Object {
-            "$ref": "#/components/schemas/Object",
+            "$ref": "#/components/schemas/Example",
             "nullable": true,
           },
           "nullableIntegerValue": Object {
@@ -189,7 +195,7 @@ Object {
             "type": "string",
           },
           "optionalEnumValue": Object {
-            "$ref": "#/components/schemas/Object",
+            "$ref": "#/components/schemas/Example",
           },
           "optionalIntegerValue": Object {
             "type": "integer",
@@ -231,7 +237,7 @@ Object {
             "type": "string",
           },
           "requiredEnumValue": Object {
-            "$ref": "#/components/schemas/Object",
+            "$ref": "#/components/schemas/Example",
           },
           "requiredIntegerValue": Object {
             "type": "integer",
@@ -320,12 +326,6 @@ Object {
           "requiredStringValue",
         ],
         "type": "object",
-      },
-      "Object": Object {
-        "enum": Array [
-          "Value",
-        ],
-        "type": "string",
       },
     },
   },

--- a/src/flavors/__tests__/fixtures.ts
+++ b/src/flavors/__tests__/fixtures.ts
@@ -57,6 +57,7 @@ export function createFixtures(flavor: Flavor): Constructor {
 
         @IsEnum({
             enum: ExampleEnum,
+            enumName: 'Example',
         })
         requiredEnumValue!: ExampleEnum;
 
@@ -108,6 +109,7 @@ export function createFixtures(flavor: Flavor): Constructor {
 
         @IsEnum({
             enum: ExampleEnum,
+            enumName: 'Example',
             optional: true,
         })
         optionalEnumValue?: ExampleEnum;
@@ -169,6 +171,7 @@ export function createFixtures(flavor: Flavor): Constructor {
 
         @IsEnum({
             enum: ExampleEnum,
+            enumName: 'Example',
             nullable: true,
         })
         nullableEnumValue!: ExampleEnum | null;

--- a/src/recipes/is-enum.recipe.ts
+++ b/src/recipes/is-enum.recipe.ts
@@ -1,4 +1,5 @@
 import { IsEnum } from 'class-validator';
+import 'reflect-metadata';
 
 import { BuilderClass, EnumOptions } from '../interfaces';
 
@@ -15,7 +16,7 @@ export function IsEnumRecipe<Options extends EnumOptions>(
          * `enumName` is used.
          */
         enum: options.enum,
-        enumName: options.enumName || options.enum.constructor.name,
+        enumName: options.enumName,
     }).add(
         // validate data as an enum
         IsEnum(options.enum),


### PR DESCRIPTION
Enums become `Object` at runtime, unfortunately.