### PR TITLE
Enable sub-package exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ export class ExampleDTO {
 With `nest-dto`, this declaration becomes:
 
 ```ts
-import { openapi } from '@hippo-oss/nest-dto';
+import { IsInteger } from '@hippo-oss/nest-dto/openapi';
 
 
 export class ExampleDTO {
 
-    @openapi.IsInteger({
+    @IsInteger({
         description: 'An example value',
     })
     public value!: number;

--- a/basic/package.json
+++ b/basic/package.json
@@ -1,0 +1,4 @@
+{
+    "main": "../dist/flavors/basic.js",
+    "types": "../dist/flavors/basic.d.ts"
+}

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,0 @@
-export * from './src';

--- a/openapi/package.json
+++ b/openapi/package.json
@@ -1,0 +1,4 @@
+{
+    "main": "../dist/flavors/openapi.js",
+    "types": "../dist/flavors/openapi.d.ts"
+}

--- a/package.json
+++ b/package.json
@@ -13,9 +13,19 @@
         "Swagger"
     ],
     "private": false,
+    "types": "dist/index.d.ts",
     "files": [
-        "dist"
+        "dist",
+        "*.d.ts",
+        "basic",
+        "openapi"
     ],
+    "exports": {
+        ".": "./dist/index.js",
+        "./basic": "./dist/flavors/basic.js",
+        "./openapi": "./dist/flavors/openapi.js",
+        "./package.json": "./package.json"
+    },
     "scripts": {
         "build": "tsc --build tsconfig.build.json",
         "build:force": "tsc --build tsconfig.build.json --force",

--- a/src/flavors/__tests__/basic.test.ts
+++ b/src/flavors/__tests__/basic.test.ts
@@ -1,11 +1,11 @@
 import { plainToClass } from 'class-transformer';
 import { validate } from 'class-validator';
 
-import { flavor } from '../basic';
+import * as basic from '../basic';
 import { INPUT, createFixtures } from './fixtures';
 
 describe('flavors.basic', () => {
-    const Example = createFixtures(flavor);
+    const Example = createFixtures(basic);
 
     it('validates required fields', async () => {
         const obj = plainToClass(Example, {});

--- a/src/flavors/__tests__/openapi.test.ts
+++ b/src/flavors/__tests__/openapi.test.ts
@@ -4,11 +4,11 @@ import { Test } from '@nestjs/testing';
 import { plainToClass } from 'class-transformer';
 import { validate } from 'class-validator';
 
-import { flavor } from '../openapi';
+import * as openapi from '../openapi';
 import { INPUT, createFixtures } from './fixtures';
 
 describe('flavors.openapi', () => {
-    const Example = createFixtures(flavor);
+    const Example = createFixtures(openapi);
 
     /* NB: it's tricky to correctly define the return type of `createFixtures` and
      * we get a "refers to a value, but is being used as a type here" compiler error

--- a/src/flavors/basic.ts
+++ b/src/flavors/basic.ts
@@ -7,7 +7,6 @@ import {
     DateOptions,
     DateStringOptions,
     EnumOptions,
-    Flavor,
     IntegerOptions,
     NestedOptions,
     NumberOptions,
@@ -40,15 +39,13 @@ function createBuilderWithMixins<Options>() {
     );
 }
 
-export const flavor: Flavor = {
-    IsArray: IsArrayRecipe(createBuilderWithMixins<ArrayOptions>()),
-    IsBoolean: IsBooleanRecipe(createBuilderWithMixins<BooleanOptions>()),
-    IsDate: IsDateRecipe(createBuilderWithMixins<DateOptions>()),
-    IsDateString: IsDateStringRecipe(createBuilderWithMixins<DateStringOptions>()),
-    IsEnum: IsEnumRecipe(createBuilderWithMixins<EnumOptions>()),
-    IsInteger: IsIntegerRecipe(createBuilderWithMixins<IntegerOptions>()),
-    IsNested: IsNestedRecipe(createBuilderWithMixins<NestedOptions>()),
-    IsNumber: IsNumberRecipe(createBuilderWithMixins<NumberOptions>()),
-    IsString: IsStringRecipe(createBuilderWithMixins<StringOptions>()),
-    IsUUID: IsUUIDRecipe(createBuilderWithMixins<UUIDOptions>()),
-};
+export const IsArray = IsArrayRecipe(createBuilderWithMixins<ArrayOptions>());
+export const IsBoolean = IsBooleanRecipe(createBuilderWithMixins<BooleanOptions>());
+export const IsDate = IsDateRecipe(createBuilderWithMixins<DateOptions>());
+export const IsDateString = IsDateStringRecipe(createBuilderWithMixins<DateStringOptions>());
+export const IsEnum = IsEnumRecipe(createBuilderWithMixins<EnumOptions>());
+export const IsInteger = IsIntegerRecipe(createBuilderWithMixins<IntegerOptions>());
+export const IsNested = IsNestedRecipe(createBuilderWithMixins<NestedOptions>());
+export const IsNumber = IsNumberRecipe(createBuilderWithMixins<NumberOptions>());
+export const IsString = IsStringRecipe(createBuilderWithMixins<StringOptions>());
+export const IsUUID = IsUUIDRecipe(createBuilderWithMixins<UUIDOptions>());

--- a/src/flavors/index.ts
+++ b/src/flavors/index.ts
@@ -1,2 +1,2 @@
-export { flavor as basic } from './basic';
-export { flavor as openapi } from './openapi';
+export * as basic from './basic';
+export * as openapi from './openapi';

--- a/src/flavors/openapi.ts
+++ b/src/flavors/openapi.ts
@@ -7,7 +7,6 @@ import {
     DateOptions,
     DateStringOptions,
     EnumOptions,
-    Flavor,
     IntegerOptions,
     NestedOptions,
     NumberOptions,
@@ -43,15 +42,13 @@ function createBuilderWithMixins<Options>() {
     );
 }
 
-export const flavor: Flavor = {
-    IsArray: IsArrayRecipe(createBuilderWithMixins<ArrayOptions>()),
-    IsBoolean: IsBooleanRecipe(createBuilderWithMixins<BooleanOptions>()),
-    IsDate: IsDateRecipe(createBuilderWithMixins<DateOptions>()),
-    IsDateString: IsDateStringRecipe(createBuilderWithMixins<DateStringOptions>()),
-    IsEnum: IsEnumRecipe(createBuilderWithMixins<EnumOptions>()),
-    IsInteger: IsIntegerRecipe(createBuilderWithMixins<IntegerOptions>()),
-    IsNested: IsNestedRecipe(createBuilderWithMixins<NestedOptions>()),
-    IsNumber: IsNumberRecipe(createBuilderWithMixins<NumberOptions>()),
-    IsString: IsStringRecipe(createBuilderWithMixins<StringOptions>()),
-    IsUUID: IsUUIDRecipe(createBuilderWithMixins<UUIDOptions>()),
-};
+export const IsArray = IsArrayRecipe(createBuilderWithMixins<ArrayOptions>());
+export const IsBoolean = IsBooleanRecipe(createBuilderWithMixins<BooleanOptions>());
+export const IsDate = IsDateRecipe(createBuilderWithMixins<DateOptions>());
+export const IsDateString = IsDateStringRecipe(createBuilderWithMixins<DateStringOptions>());
+export const IsEnum = IsEnumRecipe(createBuilderWithMixins<EnumOptions>());
+export const IsInteger = IsIntegerRecipe(createBuilderWithMixins<IntegerOptions>());
+export const IsNested = IsNestedRecipe(createBuilderWithMixins<NestedOptions>());
+export const IsNumber = IsNumberRecipe(createBuilderWithMixins<NumberOptions>());
+export const IsString = IsStringRecipe(createBuilderWithMixins<StringOptions>());
+export const IsUUID = IsUUIDRecipe(createBuilderWithMixins<UUIDOptions>());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
         "target": "es2019",
         "sourceMap": true,
         "outDir": "./dist",
-        "rootDir": "./",
+        "rootDir": "./src",
         "incremental": true,
         "forceConsistentCasingInFileNames": true,
         "resolveJsonModule": true,


### PR DESCRIPTION
After a great deal of trial-and-error, I was able to adapt one of the suggested
solutions from this [thread](https://github.com/microsoft/TypeScript/issues/33079)
to enable sub-package exports of the decorator flavors.

The solution that eventually worked involves *both* declaring some standard fields
in the top-level `package.json` and *also* defining secondary `package.json` files
to allow the sub-package exports to use a relative export into the `src/` tree. This
latter trick ended up being the hard part to figure out.

I also changed the internal structure of the flavors to export more nicely; this
makes upstream integration "just work".