### PR TITLE
Implement isArray as an attribute of other decorators.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ All options are optional expect where indicated.
 | Option            | Decorator      | Description                                         |
 | ----------------- | -------------- | --------------------------------------------------- |
 | `description`     | *all*          | Description of the field; exposed in OpenAPI.       |
+| `isArray`         | *all*          | Designates and array of values.                     |
 | `nullable`        | *all*          | Whether the field can be set to `null`.             |
 | `optional`        | *all*          | Whether the field be set to `undefined` or omitted. |
 | ----------------- | -------------- | --------------------------------------------------- |
@@ -125,6 +126,39 @@ All options are optional expect where indicated.
 | ----------------- | -------------- | --------------------------------------------------- |
 | `version`         | `IsUUID`       | The type of UUID.                                   |
 
+
+### Arrays
+
+The easiest (and preferred) way to define arrays is to add the `isArray` argument to
+another decorator:
+
+```ts
+class Example {
+   @IsString({
+       isArray: true,
+   })
+   values!: string[];
+}
+```
+
+The `isArray` option may be supplied as either the literal `true` or as `ArraySizeOptions`:
+
+```ts
+class Example {
+   @IsString({
+       isArray: {
+           maxSize: 30,
+           minSize: 0,
+       },
+   })
+   values!: string[];
+}
+```
+
+Note that while the `IsArray` decorator is also supported, it is less well-suited for defining
+arrays of value types using a consistent interface and may be deprecated in the future.
+
+
 ### Enums
 
 Enumerated types work pretty much as expected:
@@ -150,3 +184,25 @@ as a value type rather than as `$ref` to a shared type. This choice may matters 
 code from an OpenAPI spec because most code generators will produce different types for every
 enum value, even if they share the same enumerated values. Defining an `enumName` (and therefore
 a `$ref` declaration) ensures that generated code sees each use of the same enum as the same type.
+
+
+### Nested Types
+
+Decorator values that use another object type should be decorated with `IsNested`:
+
+```ts
+class Child {
+    @IsString()
+    value!: string;
+}
+
+class Parent {
+     @IsNested({
+         type: Child,
+     })
+     child!: Child;
+}
+```
+
+Every child type is expected to define *at least one* decorator field. Failure to do so may result
+in errors from `class-transformer`.

--- a/src/initializers/swagger.initializer.ts
+++ b/src/initializers/swagger.initializer.ts
@@ -1,12 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { Constructor } from '../interfaces';
+import { ArraySizeOptions, Constructor } from '../interfaces';
 
 export interface SwaggerOptions {
     description?: string;
     enum?: Record<string, unknown>,
     enumName?: string;
     format?: string;
+    isArray?: boolean | ArraySizeOptions,
     nullable?: boolean;
     maxLength?: number,
     maxItems?: number,
@@ -18,21 +19,38 @@ export interface SwaggerOptions {
     type?: string | Constructor | Constructor[],
 }
 
+export function normalizeArraySizeOptions<Options extends SwaggerOptions>(
+    options: Options,
+): ArraySizeOptions | undefined {
+    if (!options.isArray) {
+        return undefined;
+    }
+
+    if (options.isArray === true) {
+        return {};
+    }
+
+    return options.isArray;
+}
+
 export function initializeSwagger<Options extends SwaggerOptions>(
     options: Options,
 ): PropertyDecorator[] {
+    const isArray = normalizeArraySizeOptions(options);
+
     return [
         ApiProperty({
             enum: options.enum,
             enumName: options.enumName,
             description: options.description,
             format: options.format,
+            isArray: !!options.isArray,
             maximum: options.maxValue,
             maxLength: options.maxLength,
-            maxItems: options.maxItems,
+            maxItems: options.maxItems !== undefined ? options.maxItems : isArray?.maxItems,
             minimum: options.minValue,
             minLength: options.minLength,
-            minItems: options.minItems,
+            minItems: options.minItems !== undefined ? options.minItems : isArray?.minItems,
             nullable: options.nullable,
             required: !options.optional,
             type: options.type,

--- a/src/interfaces/options/array.options.ts
+++ b/src/interfaces/options/array.options.ts
@@ -1,9 +1,7 @@
 import { Constructor } from '../constructor';
 
-import { DecoratorOptions } from './decorator.options';
+import { ArraySizeOptions, DecoratorOptions } from './decorator.options';
 
-export interface ArrayOptions extends DecoratorOptions {
+export interface ArrayOptions extends DecoratorOptions, ArraySizeOptions {
     type: Constructor,
-    maxItems?: number,
-    minItems?: number,
 }

--- a/src/interfaces/options/decorator.options.ts
+++ b/src/interfaces/options/decorator.options.ts
@@ -1,5 +1,11 @@
+export interface ArraySizeOptions {
+    maxItems?: number,
+    minItems?: number,
+}
+
 export interface DecoratorOptions {
     description?: string,
+    isArray?: boolean | ArraySizeOptions,
     nullable?: boolean,
     optional?: boolean,
 }

--- a/src/interfaces/options/index.ts
+++ b/src/interfaces/options/index.ts
@@ -2,6 +2,7 @@ export * from './array.options';
 export * from './boolean.options';
 export * from './date.options';
 export * from './date-string.options';
+export * from './decorator.options';
 export * from './enum.options';
 export * from './integer.options';
 export * from './nested.options';

--- a/src/recipes/is-array.recipe.ts
+++ b/src/recipes/is-array.recipe.ts
@@ -2,10 +2,35 @@ import { ArrayMinSize, ArrayMaxSize, IsArray, ValidateNested } from 'class-valid
 
 import { TypePropertyDecorator } from '../adapters';
 import { Builder } from '../builder';
-import { ArrayOptions, Initializer } from '../interfaces';
+import { ArrayOptions, ArraySizeOptions, Initializer } from '../interfaces';
 
 export function isObject<T>(value: T): boolean {
     return value !== null && typeof value === 'object';
+}
+
+export function buildArrayPropertyDecorators(
+    options?: boolean | ArraySizeOptions,
+): PropertyDecorator[] {
+    const decorators: PropertyDecorator[] = [];
+
+    if (!options) {
+        return decorators;
+    }
+
+    // validate data as array
+    decorators.push(IsArray());
+
+    // maybe: add a maximum size
+    if (options !== true && options.maxItems !== undefined) {
+        decorators.push(ArrayMaxSize(options.maxItems));
+    }
+
+    // maybe: add a minimum size
+    if (options !== true && options.minItems !== undefined) {
+        decorators.push(ArrayMinSize(options.minItems));
+    }
+
+    return decorators;
 }
 
 export function IsArrayRecipe<Options>(
@@ -22,14 +47,7 @@ export function IsArrayRecipe<Options>(
         // convert to array of nested type
         TypePropertyDecorator(() => options.type),
 
-        // validate data as array
-        IsArray(),
-
-        // maybe: add a maximum size
-        options?.maxItems !== undefined ? ArrayMaxSize(options.maxItems) : undefined,
-
-        // maybe: add a minimum size
-        options?.minItems !== undefined ? ArrayMinSize(options.minItems) : undefined,
+        ...buildArrayPropertyDecorators(options),
 
         // maybe: validate nested type
         isObject(options.type) ? ValidateNested() : undefined,

--- a/src/recipes/is-boolean.recipe.ts
+++ b/src/recipes/is-boolean.recipe.ts
@@ -3,6 +3,7 @@ import { IsBoolean } from 'class-validator';
 import { TypePropertyDecorator } from '../adapters';
 import { Builder } from '../builder';
 import { BooleanOptions, Initializer } from '../interfaces';
+import { buildArrayPropertyDecorators } from './is-array.recipe';
 
 export function IsBooleanRecipe<Options>(
     initializers: Initializer<Options>[],
@@ -15,10 +16,12 @@ export function IsBooleanRecipe<Options>(
         // set type to number
         type: 'boolean',
     }, initializers).add(
+        ...buildArrayPropertyDecorators(options.isArray),
+
         // convert strings to boolean
         TypePropertyDecorator(() => Boolean),
 
         // validate data as a boolean
-        IsBoolean(),
+        IsBoolean({ each: !!options.isArray }),
     ).build();
 }

--- a/src/recipes/is-date-string.recipe.ts
+++ b/src/recipes/is-date-string.recipe.ts
@@ -2,6 +2,7 @@ import { IsISO8601 } from 'class-validator';
 
 import { Builder } from '../builder';
 import { DateStringOptions, Initializer } from '../interfaces';
+import { buildArrayPropertyDecorators } from './is-array.recipe';
 
 const DEFAULT_FORMAT = 'date';
 
@@ -17,7 +18,9 @@ export function IsDateStringRecipe<Options>(
         type: 'string',
         format: options?.format || DEFAULT_FORMAT,
     }, initializers).add(
+        ...buildArrayPropertyDecorators(options.isArray),
+
         // validate data as a DateString
-        IsISO8601(),
+        IsISO8601({}, { each: !!options.isArray }),
     ).build();
 }

--- a/src/recipes/is-date.recipe.ts
+++ b/src/recipes/is-date.recipe.ts
@@ -3,6 +3,7 @@ import { IsDate } from 'class-validator';
 import { TypePropertyDecorator } from '../adapters';
 import { Builder } from '../builder';
 import { DateOptions, Initializer } from '../interfaces';
+import { buildArrayPropertyDecorators } from './is-array.recipe';
 
 const DEFAULT_FORMAT = 'date-time';
 
@@ -18,12 +19,14 @@ export function IsDateRecipe<Options>(
         type: 'string',
         format: options?.format || DEFAULT_FORMAT,
     }, initializers).add(
-        // TODO: validate the input string before transforming to a Date object
+        ...buildArrayPropertyDecorators(options.isArray),
+
+        // should we validate the input string before transforming to a Date object?
 
         // convert strings to Dates
         TypePropertyDecorator(() => Date),
 
         // validate data as a Date
-        IsDate(),
+        IsDate({ each: !!options.isArray }),
     ).build();
 }

--- a/src/recipes/is-enum.recipe.ts
+++ b/src/recipes/is-enum.recipe.ts
@@ -3,6 +3,7 @@ import 'reflect-metadata';
 
 import { Builder } from '../builder';
 import { EnumOptions, Initializer } from '../interfaces';
+import { buildArrayPropertyDecorators } from './is-array.recipe';
 
 export function IsEnumRecipe<Options>(
     initializers: Initializer<Options>[],
@@ -19,7 +20,9 @@ export function IsEnumRecipe<Options>(
         enum: options.enum,
         enumName: options.enumName,
     }, initializers).add(
+        ...buildArrayPropertyDecorators(options.isArray),
+
         // validate data as an enum
-        IsEnum(options.enum),
+        IsEnum(options.enum, { each: !!options.isArray }),
     ).build();
 }

--- a/src/recipes/is-integer.recipe.ts
+++ b/src/recipes/is-integer.recipe.ts
@@ -3,6 +3,7 @@ import { IsInt, Max, Min } from 'class-validator';
 import { TypePropertyDecorator } from '../adapters';
 import { Builder } from '../builder';
 import { Initializer, IntegerOptions } from '../interfaces';
+import { buildArrayPropertyDecorators } from './is-array.recipe';
 
 export function IsIntegerRecipe<Options>(
     initializers: Initializer<Options>[],
@@ -15,16 +16,18 @@ export function IsIntegerRecipe<Options>(
         // set type to number
         type: 'integer',
     }, initializers).add(
+        ...buildArrayPropertyDecorators(options.isArray),
+
         // convert strings to numbers
         TypePropertyDecorator(() => Number),
 
         // validate data as an integer
-        IsInt(),
+        IsInt({ each: !!options.isArray }),
 
         // maybe: add a maximum value
-        options?.maxValue !== undefined ? Max(options.maxValue) : undefined,
+        options?.maxValue !== undefined ? Max(options.maxValue, { each: !!options.isArray }) : undefined,
 
         // maybe: add a minimum value
-        options?.minValue !== undefined ? Min(options.minValue) : undefined,
+        options?.minValue !== undefined ? Min(options.minValue, { each: !!options.isArray }) : undefined,
     ).build();
 }

--- a/src/recipes/is-nested.recipe.ts
+++ b/src/recipes/is-nested.recipe.ts
@@ -3,6 +3,7 @@ import { ValidateNested } from 'class-validator';
 import { TypePropertyDecorator } from '../adapters';
 import { Builder } from '../builder';
 import { Initializer, NestedOptions } from '../interfaces';
+import { buildArrayPropertyDecorators } from './is-array.recipe';
 
 export function IsNestedRecipe<Options>(
     initializers: Initializer<Options>[],
@@ -15,10 +16,12 @@ export function IsNestedRecipe<Options>(
         // set type to nested type
         type: options.type,
     }, initializers).add(
+        ...buildArrayPropertyDecorators(options.isArray),
+
         // convert to nested type
         TypePropertyDecorator(() => options.type),
 
         // validate nested
-        ValidateNested(),
+        ValidateNested({ each: !!options.isArray }),
     ).build();
 }

--- a/src/recipes/is-number.recipe.ts
+++ b/src/recipes/is-number.recipe.ts
@@ -3,6 +3,7 @@ import { IsNumber, Max, Min } from 'class-validator';
 import { TypePropertyDecorator } from '../adapters';
 import { Builder } from '../builder';
 import { Initializer, NumberOptions } from '../interfaces';
+import { buildArrayPropertyDecorators } from './is-array.recipe';
 
 export function IsNumberRecipe<Options>(
     initializers: Initializer<Options>[],
@@ -15,16 +16,18 @@ export function IsNumberRecipe<Options>(
         // set type to number
         type: 'number',
     }, initializers).add(
+        ...buildArrayPropertyDecorators(options.isArray),
+
         // convert strings to numbers
         TypePropertyDecorator(() => Number),
 
         // validate data as a number
-        IsNumber(),
+        IsNumber({}, { each: !!options.isArray }),
 
         // maybe: add a maximum value
-        options?.maxValue !== undefined ? Max(options.maxValue) : undefined,
+        options?.maxValue !== undefined ? Max(options.maxValue, { each: !!options.isArray }) : undefined,
 
         // maybe: add a minimum value
-        options?.minValue !== undefined ? Min(options.minValue) : undefined,
+        options?.minValue !== undefined ? Min(options.minValue, { each: !!options.isArray }) : undefined,
     ).build();
 }

--- a/src/recipes/is-string.recipe.ts
+++ b/src/recipes/is-string.recipe.ts
@@ -2,6 +2,7 @@ import { IsString, Matches, MaxLength, MinLength } from 'class-validator';
 
 import { Builder } from '../builder';
 import { StringOptions, Initializer } from '../interfaces';
+import { buildArrayPropertyDecorators } from './is-array.recipe';
 
 export function IsStringRecipe<Options>(
     initializers: Initializer<Options>[],
@@ -14,16 +15,18 @@ export function IsStringRecipe<Options>(
         // set type to number
         type: 'string',
     }, initializers).add(
+        ...buildArrayPropertyDecorators(options.isArray),
+
         // validate data as a string
-        IsString(),
+        IsString({ each: !!options.isArray }),
 
         // maybe: add a maximum length
-        options?.maxLength !== undefined ? MaxLength(options.maxLength) : undefined,
+        options?.maxLength !== undefined ? MaxLength(options.maxLength, { each: !!options.isArray }) : undefined,
 
         // maybe: add a minimum length
-        options?.minLength !== undefined ? MinLength(options.minLength) : undefined,
+        options?.minLength !== undefined ? MinLength(options.minLength, { each: !!options.isArray }) : undefined,
 
         // maybe: add a regex
-        options?.pattern !== undefined ? Matches(options.pattern) : undefined,
+        options?.pattern !== undefined ? Matches(options.pattern, { each: !!options.isArray }) : undefined,
     ).build();
 }

--- a/src/recipes/is-uuid.recipe.ts
+++ b/src/recipes/is-uuid.recipe.ts
@@ -2,6 +2,7 @@ import { IsUUID } from 'class-validator';
 
 import { Builder } from '../builder';
 import { Initializer, UUIDOptions } from '../interfaces';
+import { buildArrayPropertyDecorators } from './is-array.recipe';
 
 export function IsUUIDRecipe<Options>(
     initializers: Initializer<Options>[],
@@ -15,7 +16,9 @@ export function IsUUIDRecipe<Options>(
         type: 'string',
         format: 'uuid',
     }, initializers).add(
+        ...buildArrayPropertyDecorators(options.isArray),
+
         // validate data as a string
-        IsUUID(options?.version),
+        IsUUID(options?.version, { each: !!options.isArray }),
     ).build();
 }


### PR DESCRIPTION
Our `IsArray` decorator has turned out to be somewhat awkward because
it cannot practically specify type-specific validation of the array's
items. For example, it cannot say that an array contains integers,
all of which are greater than zero.

The best alternative is to add an `isArray` option to each typed
decorator. We'll likely deprecate `IsArray` eventually as well.