### PR TITLE
Allow examples as part of nest-dto interface.

### DIFF
--- a/src/initializers/swagger.initializer.ts
+++ b/src/initializers/swagger.initializer.ts
@@ -5,20 +5,20 @@ import { ArraySizeOptions } from '../options';
 
 export interface SwaggerOptions {
     description?: string;
-    enum?: Record<string, unknown>,
+    example?: unknown;
+    enum?: Record<string, unknown>;
     enumName?: string;
-    example?: string;
     format?: string;
-    isArray?: boolean | ArraySizeOptions,
+    isArray?: boolean | ArraySizeOptions;
     nullable?: boolean;
-    maxLength?: number,
-    maxItems?: number,
-    maxValue?: number,
-    minLength?: number,
-    minItems?: number,
-    minValue?: number,
-    optional?: boolean,
-    type?: string | Type | Type[],
+    maxLength?: number;
+    maxItems?: number;
+    maxValue?: number;
+    minLength?: number;
+    minItems?: number;
+    minValue?: number;
+    optional?: boolean;
+    type?: string | Type | Type[];
 }
 
 export function normalizeArraySizeOptions<Options extends SwaggerOptions>(

--- a/src/options/decorator.options.ts
+++ b/src/options/decorator.options.ts
@@ -8,6 +8,7 @@ export interface ArraySizeOptions {
 
 export interface DecoratorOptions {
     description?: string,
+    example?: unknown,
     isArray?: boolean | ArraySizeOptions,
     nullable?: boolean,
     optional?: boolean,


### PR DESCRIPTION
OpenAPI supports field-level examples; we want our decorators to allow an `example` input.