### PR TITLE
Add experimental Union decorator.

### DIFF
--- a/src/decorators/__tests__/__snapshots__/union.decorator.test.ts.snap
+++ b/src/decorators/__tests__/__snapshots__/union.decorator.test.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`decorators Union generates a oneOf definition 1`] = `
+Object {
+  "components": Object {
+    "schemas": Object {
+      "Foo": Object {
+        "properties": Object {
+          "bar": Object {
+            "oneOf": Array [
+              Object {
+                "type": "string",
+              },
+              Object {
+                "type": "number",
+              },
+            ],
+          },
+        },
+        "required": Array [
+          "bar",
+        ],
+        "type": "object",
+      },
+    },
+  },
+  "info": Object {
+    "contact": Object {},
+    "description": "",
+    "title": "",
+    "version": "1.0.0",
+  },
+  "openapi": "3.0.0",
+  "paths": Object {
+    "/": Object {
+      "get": Object {
+        "operationId": "FixtureController_fixture",
+        "parameters": Array [],
+        "responses": Object {
+          "default": Object {
+            "content": Object {
+              "application/json": Object {
+                "schema": Object {
+                  "$ref": "#/components/schemas/Foo",
+                },
+              },
+            },
+            "description": "",
+          },
+        },
+      },
+    },
+  },
+  "servers": Array [],
+  "tags": Array [],
+}
+`;

--- a/src/decorators/__tests__/union.decorator.test.ts
+++ b/src/decorators/__tests__/union.decorator.test.ts
@@ -1,0 +1,26 @@
+import { IsNumber, IsString } from '../../flavors/openapi';
+import {
+    createOpenAPIDocument,
+    createOpenAPIFixtureModule,
+} from '../../testing';
+import { Union } from '../union.decorator';
+
+class Foo {
+
+    @Union([
+        IsString,
+        IsNumber,
+    ])
+    bar!: string | number;
+}
+
+describe('decorators', () => {
+    describe('Union', () => {
+        it('generates a oneOf definition', async () => {
+            const FixtureModule = createOpenAPIFixtureModule(Foo);
+            const document = await createOpenAPIDocument(FixtureModule);
+
+            expect(document).toMatchSnapshot();
+        });
+    });
+});

--- a/src/decorators/union.decorator.ts
+++ b/src/decorators/union.decorator.ts
@@ -1,0 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsBoolean, IsInteger, IsNumber, IsString } from '../flavors/openapi';
+
+export type OpenAPIDecoratorType = typeof IsBoolean
+    | typeof IsInteger
+    | typeof IsNumber
+    | typeof IsString;
+
+export type OpenAPIType = 'boolean' | 'integer' | 'number' | 'string';
+
+export interface OpenAPIRef {
+    $ref: string;
+}
+
+export function asType(item: OpenAPIDecoratorType): OpenAPIType {
+    switch (item) {
+        case IsBoolean:
+            return 'boolean';
+        case IsInteger:
+            return 'integer';
+        case IsNumber:
+            return 'number';
+        case IsString:
+            return 'string';
+        default:
+            break;
+    }
+
+    throw new Error('Missing case statement');
+}
+
+export function Union(types: OpenAPIDecoratorType[]): PropertyDecorator {
+    return ApiProperty({
+        oneOf: types.map(
+            (item) => ({
+                type: asType(item),
+            }),
+        ),
+    });
+}


### PR DESCRIPTION
We have at least one business case where a single field can contain either a numeric
value or a string value. While we _could_ implement this scenario using two fields,
it's a lot nicer (in TypeScript) to use a union type because it allows you express
that exactly one value is defined.

However, in the DTO layer, union types are trickier, perhaps so much that the benefit
of union types isn't worth the complexity:

 - You have to write a transformer layer that is aware of validation and essentially
   does a try/catch on each possible transformation contingent on validation.

 - You have to use `oneOf` at the OpenAPI layer, which, while possible, isn't clean.

This PR demonstrates how a `@Union()` decorator that implements `oneOf` might look
and hopefully demonstrates the consequences.