### PR TITLE
Automatically transform nullToUndefined

### DIFF
--- a/src/initializers/__tests__/transformer.initializer.test.ts
+++ b/src/initializers/__tests__/transformer.initializer.test.ts
@@ -70,5 +70,23 @@ describe('initializers', () => {
             const obj = plainToClass(Fixture, plain, options);
             expect(obj.value).not.toBeDefined();
         });
+        it('transform null to undefinded', () => {
+            const builder = new Builder<TransformerOptions>({
+                expose: true,
+                optional: true,
+                nullable: false,
+            }, initializers);
+            expect(builder.decorators).toHaveLength(2);
+
+            const decorator = builder.build();
+
+            class Fixture {
+                @decorator
+                public value?: string;
+            }
+
+            const obj = plainToClass(Fixture, { value: null }, options);
+            expect(obj.value).not.toBeDefined();
+        });
     });
 });

--- a/src/initializers/transformer.initializer.ts
+++ b/src/initializers/transformer.initializer.ts
@@ -1,20 +1,29 @@
-import { ExposeOptions } from 'class-transformer';
+import { ExposeOptions, Transform } from 'class-transformer';
+
 import { ExposePropertyDecorator } from '../adapters';
+import { nullToUndefined } from '../operators';
 
 export interface TransformerOptions {
     expose?: boolean;
+    nullable?: boolean,
+    optional?: boolean,
 }
 
 export function initializeTransformer<Options extends TransformerOptions>(
     options: Options,
 ): PropertyDecorator[] {
-    if (!options.expose) {
-        return [];
+
+    const decorators: PropertyDecorator[] = [];
+
+    if (options.expose) {
+        decorators.push(ExposePropertyDecorator(options as ExposeOptions));
     }
 
-    return [
-        ExposePropertyDecorator(options as ExposeOptions),
-    ];
+    if (!options.nullable && options.optional) {
+        decorators.push(Transform(nullToUndefined));
+    }
+
+    return decorators;
 }
 
 export function initializeStrictTransformer<Options extends TransformerOptions>(


### PR DESCRIPTION
If a decorator is `optional` but is NOT `nullable`, we can automatically
convert null inputs to undefined.

In theory, this conversion could swallow some error conditions. We're basically
trading off the ability to catch (and fail upon) null being provided in case
where it's not allowed against the ability to omit conversion in cases where
null is more common (e.g. databases). This trade-off feels worth it.