### PR TITLE
Enable class-transformer (re)naming of a field.

### DIFF
--- a/src/initializers/__tests__/transformer.initializer.test.ts
+++ b/src/initializers/__tests__/transformer.initializer.test.ts
@@ -1,4 +1,4 @@
-import { plainToClass } from 'class-transformer';
+import { classToPlain, plainToClass } from 'class-transformer';
 
 import { Builder } from '../../builder';
 import { TransformerOptions, initializeTransformer } from '../transformer.initializer';
@@ -87,6 +87,26 @@ describe('initializers', () => {
 
             const obj = plainToClass(Fixture, { value: null }, options);
             expect(obj.value).not.toBeDefined();
+        });
+        it('supports renaming fields', () => {
+            const builder = new Builder<TransformerOptions>({
+                expose: true,
+                name: 'foo_bar',
+            }, initializers);
+            expect(builder.decorators).toHaveLength(1);
+
+            const decorator = builder.build();
+
+            class Fixture {
+                @decorator
+                public fooBar!: string;
+            }
+
+            const obj = plainToClass(Fixture, { foo_bar: 'baz' }, options);
+            expect(obj.fooBar).toEqual('baz');
+            expect(classToPlain(obj)).toEqual({
+                foo_bar: 'baz',
+            });
         });
     });
 });

--- a/src/initializers/transformer.initializer.ts
+++ b/src/initializers/transformer.initializer.ts
@@ -5,6 +5,7 @@ import { nullToUndefined } from '../operators';
 
 export interface TransformerOptions {
     expose?: boolean;
+    name?: string;
     nullable?: boolean,
     optional?: boolean,
 }


### PR DESCRIPTION
We have some legacy scenarios where the DTO types and the JSON types do not match.
Rather than force the DTO types to use non-standard naming, we can have
`class-transformer` convert for us.